### PR TITLE
Add imagePullSecrets, env for deployment

### DIFF
--- a/src/spaceone/supervisor/connector/kubernetes_connector.py
+++ b/src/spaceone/supervisor/connector/kubernetes_connector.py
@@ -223,6 +223,12 @@ class KubernetesConnector(ContainerConnector):
         if self.service_account:
             deployment['spec']['serviceAccountName'] = self.service_account
 
+        if _image_pull_secrets := self.config.get('imagePullSecrets'):
+            deployment['spec']['template']['spec']['imagePullSecrets'] = _image_pull_secrets
+
+        if _container_env := self.config.get('env'):
+            deployment['spec']['template']['spec']['containers'][0]['env'] = _container_env
+
         return deployment
 
     def _update_endpoints(self, svc_name):

--- a/src/spaceone/supervisor/service/supervisor_service.py
+++ b/src/spaceone/supervisor/service/supervisor_service.py
@@ -112,14 +112,14 @@ class SupervisorService(BaseService):
             self._release_lock(domain_id, name)
             return False
 
-        print("XXXXXXXXXXXXXXXXXXXXXX Check Plugin State XXXXXXXXXXXXXXXXX")
+        _LOGGER.debug(f'[sync_plugins] Check Plugin State')
         # if plugin state == RE_PROVISION, delete first
         try:
             self._check_plugin_state(plugins.results, params)
         except Exception as e:
             _LOGGER.error(f'[sync_plugins] fail to check plugins, {e}')
 
-        print("XXXXXXXXXXXXXXXXXXXXXX Install XXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+        _LOGGER.debug(f'[sync_plugins] Install Plugins')
         try:
             self._install_plugins(plugins.results, params)
         except Exception as e:
@@ -127,7 +127,7 @@ class SupervisorService(BaseService):
             self._release_lock(domain_id, name)
             raise ERROR_INSTALL_PLUGINS(plugins)
 
-        print("XXXXXXXXXXXXXXXXXXXXX Clean-up XXXXXXXXXXXXXXXXXXXXXXXXXXX")
+        _LOGGER.debug(f'[sync_plugins] Clean up Plugins')
         try:
             self._delete_plugins(plugins.results, params)
         except Exception as e:
@@ -136,7 +136,7 @@ class SupervisorService(BaseService):
             raise ERROR_DELETE_PLUGINS(plugins=plugins)
 
         # Publish Again
-        print("XXXXXXXXXXXXXXXXXXXXXXX Publish XXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+        _LOGGER.debug(f'[sync_plugins] Publish Supervisor')
         try:
             self.publish_supervisor(params)
         except Exception as e:


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
* When deploying a container through supervisor, you can set `imagePullSecrets` to pull a container image from a private repository that requires authentication
* Can add to inject environment variables into the container.

### Known issue
* https://github.com/cloudforet-io/supervisor/issues/8
