### PR TITLE
fix: remove transaction variable used when initializing in manager, connector and service

### DIFF
--- a/src/spaceone/supervisor/connector/container_connector.py
+++ b/src/spaceone/supervisor/connector/container_connector.py
@@ -21,8 +21,8 @@ from spaceone.core.error import ERROR_NOT_IMPLEMENTED
 
 
 class ContainerConnector(BaseConnector):
-    def __init__(self, transaction, config=None, **kwargs):
-        super().__init__(transaction, config, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def search(self, filters):
         raise ERROR_NOT_IMPLEMENTED(name='search')

--- a/src/spaceone/supervisor/connector/docker_connector.py
+++ b/src/spaceone/supervisor/connector/docker_connector.py
@@ -31,10 +31,8 @@ MAX_COUNT = 180
 
 
 class DockerConnector(ContainerConnector):
-    def __init__(self, transaction, config=None, **kwargs):
-        print("X" * 100)
-        print(kwargs)
-        super().__init__(transaction, config, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         _LOGGER.debug(f'[DockerConnector] config: {self.config}')
         try:
             self.client = docker.DockerClient(base_url='unix://var/run/docker.sock')

--- a/src/spaceone/supervisor/connector/kubernetes_connector.py
+++ b/src/spaceone/supervisor/connector/kubernetes_connector.py
@@ -34,8 +34,8 @@ ENDPOINT_INTERVAL = 10
 
 class KubernetesConnector(ContainerConnector):
 
-    def __init__(self, transaction, config=None, **kwargs):
-        super().__init__(transaction, config, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         _LOGGER.debug("[KubernetesConnector] config: %s" % self.config)
         self.headless = self.config.get('headless', False)
         self.node_selector = self.config.get('nodeSelector', {})

--- a/src/spaceone/supervisor/connector/plugin_connector.py
+++ b/src/spaceone/supervisor/connector/plugin_connector.py
@@ -27,8 +27,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class PluginConnector(BaseConnector):
-    def __init__(self, transaction, config):
-        super().__init__(transaction, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         _LOGGER.debug("config: %s" % self.config)
         if 'endpoint' not in self.config:
             raise ERROR_WRONG_CONFIGURATION(key='endpoint')

--- a/src/spaceone/supervisor/connector/repository_connector.py
+++ b/src/spaceone/supervisor/connector/repository_connector.py
@@ -27,8 +27,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class RepositoryConnector(BaseConnector):
-    def __init__(self, transaction, config):
-        super().__init__(transaction, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         _LOGGER.debug("config: %s" % self.config)
         if 'endpoint' not in self.config:
             raise ERROR_WRONG_CONFIGURATION(key='endpoint')

--- a/src/spaceone/supervisor/manager/plugin_service_manager.py
+++ b/src/spaceone/supervisor/manager/plugin_service_manager.py
@@ -25,8 +25,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class PluginServiceManager(BaseManager):
-    def __init__(self, transaction):
-        super().__init__(transaction)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def publish_supervisor(self, params):
         """ Get connector for plugin

--- a/src/spaceone/supervisor/manager/supervisor_manager.py
+++ b/src/spaceone/supervisor/manager/supervisor_manager.py
@@ -24,8 +24,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class SupervisorManager(BaseManager):
-    def __init__(self, transaction):
-        super().__init__(transaction)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         # container API backend
         self.backend = config.get_global('BACKEND')
         connectors_conf = config.get_global('CONNECTORS')

--- a/src/spaceone/supervisor/service/supervisor_service.py
+++ b/src/spaceone/supervisor/service/supervisor_service.py
@@ -17,8 +17,8 @@ SUPERVISOR_SYNC_EXPIRE_TIME = 600
 
 
 class SupervisorService(BaseService):
-    def __init__(self, metadata):
-        super().__init__(metadata)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._supervisor_mgr: SupervisorManager = self.locator.get_manager('SupervisorManager')
         self._plugin_service_mgr: PluginServiceManager = self.locator.get_manager('PluginServiceManager')
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [x] Refactor
- [ ] etc

### Description
* As the transaction structure of the core framework changes, the transaction variable of the dependent microservice is removed.